### PR TITLE
feat: Allow matching absolute paths

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,53 +7,83 @@ use nodejs_semver::{Range, SemverError, Version};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
-pub struct ModuleMatcher {
-    pub name: String,
-    pub version_range: Range,
-    pub file_path: PathBuf,
+pub enum CodeMatcher {
+    Dependency {
+        name: String,
+        version_range: Range,
+        relative_path: PathBuf,
+    },
+    AbsolutePaths {
+        absolute_paths: Vec<PathBuf>,
+    },
 }
 
-impl ModuleMatcher {
-    /// Creates a new `ModuleMatcher` instance.
+#[derive(Debug, Clone)]
+pub struct Dependency {
+    pub name: String,
+    pub version: Version,
+    pub relative_path: PathBuf,
+}
+
+impl CodeMatcher {
+    /// Creates a new `Dependency` code matcher.
     /// # Errors
     /// Returns an error if the version range cannot be parsed.
-    pub fn new(name: &str, version_range: &str, file_path: &str) -> Result<Self, SemverError> {
-        Ok(Self {
+    pub fn dependency(
+        name: &str,
+        version_range: &str,
+        relative_path: &str,
+    ) -> Result<Self, SemverError> {
+        Ok(CodeMatcher::Dependency {
             name: name.to_string(),
             version_range: Range::parse(version_range)?,
-            file_path: PathBuf::from(file_path),
+            relative_path: PathBuf::from(relative_path),
         })
     }
 
     #[must_use]
-    pub fn matches(&self, module_name: &str, version: &str, file_path: &PathBuf) -> bool {
-        let version: Version = match version.parse() {
-            Ok(v) => v,
-            Err(e) => {
-                println!("Failed to parse version {version}: {e}");
-                return false;
-            }
-        };
+    pub fn absolute_paths(absolute_paths: Vec<PathBuf>) -> Self {
+        CodeMatcher::AbsolutePaths { absolute_paths }
+    }
 
-        self.name == module_name
-            && version.satisfies(&self.version_range)
-            && self.file_path == *file_path
+    #[must_use]
+    pub fn matches(&self, absolute_path: &PathBuf, dependency: Option<&Dependency>) -> bool {
+        match self {
+            CodeMatcher::Dependency {
+                name,
+                version_range,
+                relative_path,
+            } => {
+                if let Some(dependency) = dependency {
+                    *name == dependency.name
+                        && dependency.version.satisfies(version_range)
+                        && *relative_path == dependency.relative_path
+                } else {
+                    false
+                }
+            }
+            CodeMatcher::AbsolutePaths { absolute_paths } => absolute_paths.contains(absolute_path),
+        }
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct InstrumentationConfig {
     pub channel_name: String,
-    pub module: ModuleMatcher,
+    pub code_matcher: CodeMatcher,
     pub function_query: FunctionQuery,
 }
 
 impl InstrumentationConfig {
     #[must_use]
-    pub fn new(channel_name: &str, module: ModuleMatcher, function_query: FunctionQuery) -> Self {
+    pub fn new(
+        channel_name: &str,
+        code_matcher: CodeMatcher,
+        function_query: FunctionQuery,
+    ) -> Self {
         Self {
             channel_name: channel_name.to_string(),
-            module,
+            code_matcher,
             function_query,
         }
     }
@@ -82,7 +112,7 @@ impl Config {
 
 impl InstrumentationConfig {
     #[must_use]
-    pub fn matches(&self, module_name: &str, version: &str, file_path: &PathBuf) -> bool {
-        self.module.matches(module_name, version, file_path)
+    pub fn matches(&self, absolute_path: &PathBuf, dependency: Option<&Dependency>) -> bool {
+        self.code_matcher.matches(absolute_path, dependency)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,16 +65,16 @@ impl Instrumentor {
 
     /// For a given module name, version, and file path within the module, return all
     /// `Instrumentation` instances that match.
+    #[must_use]
     pub fn get_matching_instrumentations<'a>(
         &'a mut self,
-        module_name: &'a str,
-        version: &'a str,
-        file_path: &'a PathBuf,
+        absolute_path: &'a PathBuf,
+        dependency: Option<&'a Dependency>,
     ) -> InstrumentationVisitor<'a> {
         let instrumentations = self
             .instrumentations
             .iter_mut()
-            .filter(|instr| instr.matches(module_name, version, file_path));
+            .filter(move |instr| instr.matches(absolute_path, dependency));
 
         InstrumentationVisitor::new(instrumentations, self.dc_module.as_ref())
     }


### PR DESCRIPTION
- Closes #14

Replaces `ModuleMatcher` struct with a `CodeMatcher` enum which allows matching to both dependency code and absolute paths.

This changes the matching API. Now you always pass the absolute path to the file and can optionally include the dependency details if this file is in a dependency in `node_modules`.

So the JavaScript API would change to something like this:

```ts
interface InstrumentationMatcher {
  // If this returns undefined, we know there's no transforming required for this specific file
  getTransformer(absolute_path: string, dependency?: { name: string, version: string, relative_path: string }): Transformer | undefined;
}

```