### PR TITLE
Fix the same channel name being used multiple times for instrumented methods in the same module or script

### DIFF
--- a/src/instrumentation.rs
+++ b/src/instrumentation.rs
@@ -186,15 +186,22 @@ impl Instrumentation {
     // `visit_mut_children_with`.
 
     pub fn visit_mut_module(&mut self, node: &mut Module) -> bool {
-        node.body
-            .insert(1, ModuleItem::Stmt(self.create_tracing_channel()));
+        let channel_element = self.create_tracing_channel();
+        let channel_module_item = ModuleItem::Stmt(channel_element.clone());
+        if !node.body.iter().any(|item| item == &channel_module_item) {
+            node.body
+                .insert(1, ModuleItem::Stmt(channel_element));
+        }
         true
     }
 
     pub fn visit_mut_script(&mut self, node: &mut Script) -> bool {
         let start_index = get_script_start_index(node);
-        node.body
-            .insert(start_index + 1, self.create_tracing_channel());
+        let channel_element = self.create_tracing_channel();
+        if !node.body.iter().any(|item| item == &channel_element) {
+            node.body
+                .insert(start_index + 1, channel_element);
+        }
         true
     }
 

--- a/tests/instrumentor_test.rs
+++ b/tests/instrumentor_test.rs
@@ -17,3 +17,5 @@ mod multiple_load_cjs;
 mod object_method_cjs;
 mod polyfill_cjs;
 mod polyfill_mjs;
+mod single_channel_multiple_usages_cjs;
+mod single_channel_multiple_usages_mjs;

--- a/tests/single_channel_multiple_usages_cjs/mod.js
+++ b/tests/single_channel_multiple_usages_cjs/mod.js
@@ -1,0 +1,9 @@
+async function foo () {
+  return 'foo'
+}
+
+async function bar () {
+  return 'bar'
+}
+
+module.exports = { foo, bar };

--- a/tests/single_channel_multiple_usages_cjs/mod.rs
+++ b/tests/single_channel_multiple_usages_cjs/mod.rs
@@ -1,0 +1,25 @@
+use crate::common::*;
+use orchestrion_js::*;
+
+#[test]
+fn same_channel_multiple_usages_cjs() {
+  transpile_and_test(
+      file!(),
+      false,
+      Config::new(
+          vec![
+              InstrumentationConfig::new(
+                  "method_call",
+                  test_module_matcher(),
+                  FunctionQuery::function_declaration("foo", FunctionKind::Async),
+              ),
+              InstrumentationConfig::new(
+                  "method_call",
+                  test_module_matcher(),
+                  FunctionQuery::function_declaration("bar", FunctionKind::Async),
+              ),
+          ],
+          None,
+      ),
+  );
+}

--- a/tests/single_channel_multiple_usages_cjs/test.js
+++ b/tests/single_channel_multiple_usages_cjs/test.js
@@ -1,0 +1,26 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+ **/
+const { foo, bar } = require('./instrumented.js');
+const { assert, getContext } = require('../common/preamble.js');
+const context = getContext('orchestrion:undici:method_call');
+(async () => {
+  const result = await foo();
+  assert.strictEqual(result, 'foo');
+  assert.deepStrictEqual(context, {
+    start: true,
+    end: true,
+    asyncStart: 'foo',
+    asyncEnd: 'foo'
+  });
+
+  const result2 = await bar();
+  assert.strictEqual(result2, 'bar');
+  assert.deepStrictEqual(context, {
+    start: true,
+    end: true,
+    asyncStart: 'bar',
+    asyncEnd: 'bar'
+  });
+})();

--- a/tests/single_channel_multiple_usages_mjs/mod.mjs
+++ b/tests/single_channel_multiple_usages_mjs/mod.mjs
@@ -1,0 +1,9 @@
+async function foo () {
+  return 'foo'
+}
+
+async function bar () {
+  return 'bar'
+}
+
+export { foo, bar };

--- a/tests/single_channel_multiple_usages_mjs/mod.rs
+++ b/tests/single_channel_multiple_usages_mjs/mod.rs
@@ -1,0 +1,25 @@
+use crate::common::*;
+use orchestrion_js::*;
+
+#[test]
+fn same_channel_multiple_usages_mjs() {
+  transpile_and_test(
+      file!(),
+      true,
+      Config::new(
+          vec![
+              InstrumentationConfig::new(
+                  "method_call",
+                  test_module_matcher(),
+                  FunctionQuery::function_declaration("foo", FunctionKind::Async),
+              ),
+              InstrumentationConfig::new(
+                  "method_call",
+                  test_module_matcher(),
+                  FunctionQuery::function_declaration("bar", FunctionKind::Async),
+              ),
+          ],
+          None,
+      ),
+  );
+}

--- a/tests/single_channel_multiple_usages_mjs/test.mjs
+++ b/tests/single_channel_multiple_usages_mjs/test.mjs
@@ -1,0 +1,24 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2025 Datadog, Inc.
+ **/
+import { foo, bar } from './instrumented.mjs';
+import { assert, getContext } from '../common/preamble.js';
+const context = getContext('orchestrion:undici:method_call');
+const result = await foo();
+assert.strictEqual(result, 'foo');
+assert.deepStrictEqual(context, {
+  start: true,
+  end: true,
+  asyncStart: 'foo',
+  asyncEnd: 'foo'
+});
+
+const result2 = await bar();
+assert.strictEqual(result2, 'bar');
+assert.deepStrictEqual(context, {
+  start: true,
+  end: true,
+  asyncStart: 'bar',
+  asyncEnd: 'bar'
+});


### PR DESCRIPTION
Fixes #19 

Checks if a tracing channel declaration is already included in the method or script body before inserting it.

I have to admit that:
1. My Rust is almost nonexistent. But, from a straight programming standpoint, I _think_ that this approach shouldn't be too time consuming, as the channel declaration should be at the very top of the file and we shouldn't have to iterate over too many lines. But please correct me if this implementation is bad in Rust (or in general).
2.  The tests are a bit weird, asserting against the same context. I thought about using two different contexts with the same channel name, but the tests work as-is. If it's not readable, or just is more preferable in general to do two contexts, I am happy to do so instead!